### PR TITLE
ci: add generic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build / test
+        run: echo "TODO: add build and test commands for python_rest_tutorial"


### PR DESCRIPTION
## Summary
Adds a baseline GitHub Actions CI workflow for a `generic` project.

## Changes
- `.github/workflows/ci.yml` scaffolded from the standard `generic` template.

## Testing
CI pipeline should run automatically on this PR.