### PR TITLE
test: cover hello endpoint body and content type

### DIFF
--- a/web/tests/test_app.py
+++ b/web/tests/test_app.py
@@ -91,6 +91,8 @@ def test_hello_returns_200(client):
 def test_hello_returns_hello_world(client):
     rv = client.get("/hello")
     assert rv.status_code == 200
+    assert rv.get_json() == "Hello World!"
+    assert rv.headers["Content-Type"].startswith("application/json")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- assert that `/hello` returns the expected `"Hello World!"` payload
- verify the response content type is JSON rather than only re-checking the 200 status
- remove the duplicate coverage gap called out in issue #43

## Validation
- `cd web && pytest -q`

Closes #43
