### PR TITLE
fix: resolve #41 - BUG: Add global error handlers for 404, 405, and unhandled 5

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -6,16 +6,35 @@ from functools import wraps
 
 import bcrypt
 import jwt
-from flask import Flask, request
+from flask import Flask, jsonify, request
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_restful import Api, Resource
 from pymongo import MongoClient
+from werkzeug.exceptions import HTTPException
 
 # print = functools.partial(print, flush=True)
 
 app = Flask(__name__)
 api = Api(app)
+
+
+# Flask-Restful's Api.handle_error builds its own response for HTTP
+# exceptions and never consults Flask's @app.errorhandler chain. Route
+# all HTTP exceptions through Flask's dispatch so our app-level error
+# handlers (registered via @app.errorhandler) are invoked.
+def _patched_handle_error(e):
+    if isinstance(e, HTTPException):
+        return app.handle_http_exception(e)
+    # For unhandled Python exceptions (e.g. KeyError from a bug in an
+    # endpoint), flask-restful's default handle_error builds its own JSON
+    # response and never consults Flask's @app.errorhandler chain. Raise
+    # so that Api.error_router falls through to the original Flask handler,
+    # which will route the error through @app.errorhandler(500).
+    raise e
+
+
+api.handle_error = _patched_handle_error
 
 limiter = Limiter(
     get_remote_address,
@@ -175,6 +194,21 @@ api.add_resource(Register, "/register")
 api.add_resource(Login, "/login")
 api.add_resource(Retrieve, "/retrieve")
 api.add_resource(Save, "/save")
+
+
+@app.errorhandler(404)
+def handle_404(e):
+    return jsonify({"status": 404, "msg": "Not found"}), 404
+
+
+@app.errorhandler(405)
+def handle_405(e):
+    return jsonify({"status": 405, "msg": "Method not allowed"}), 405
+
+
+@app.errorhandler(500)
+def handle_500(e):
+    return jsonify({"status": 500, "msg": "Internal server error"}), 500
 
 
 if __name__ == "__main__":

--- a/web/tests/test_app.py
+++ b/web/tests/test_app.py
@@ -315,3 +315,26 @@ def test_register_rate_limit_returns_429_after_threshold(mock_users, rate_limite
     assert responses[:5] == [200] * 5
     # The 6th request within the window is throttled.
     assert responses[5] == 429
+
+
+# ---------------------------------------------------------------------------
+# Global error handlers
+# ---------------------------------------------------------------------------
+
+
+def test_404_returns_json_for_nonexistent_route(client):
+    rv = client.get("/nonexistent")
+    assert rv.status_code == 404
+    assert rv.headers["Content-Type"] == "application/json"
+    data = rv.get_json()
+    assert data["status"] == 404
+    assert data["msg"] == "Not found"
+
+
+def test_405_returns_json_for_wrong_method_on_existing_route(client):
+    rv = client.get("/register")
+    assert rv.status_code == 405
+    assert rv.headers["Content-Type"] == "application/json"
+    data = rv.get_json()
+    assert data["status"] == 405
+    assert data["msg"] == "Method not allowed"


### PR DESCRIPTION
## Summary

Resolves #41 — Adds global JSON error handlers for 404, 405, and 500 errors so the API returns consistent JSON responses instead of Flask's default HTML error pages, improving API contract consistency for clients.

## Changes

- **web/app.py**: Patching `api.handle_error` to route HTTP exceptions through Flask's dispatch so `@app.errorhandler` registrations are invoked (Flask-Restful's default handler builds its own response and never consults the errorhandler chain). Added three error handlers (404, 405, 500) that return JSON with `{"status": N, "msg": "..."}` shape, matching the existing API response format. Added `jsonify` and `HTTPException` imports.

- **web/tests/test_app.py**: Added two test cases — `test_404_returns_json_for_nonexistent_route` verifies that GET /nonexistent returns 404 with JSON content type and the expected `status`/`msg` fields; `test_405_returns_json_for_wrong_method_on_existing_route` verifies that GET /register (which only accepts POST) returns 405 JSON.

## Testing

- Run `pytest -v web/tests/test_app.py` — the new tests `test_404_returns_json_for_nonexistent_route` and `test_405_returns_json_for_wrong_method_on_existing_route` should pass.
- Manual verification: `curl -i http://localhost:5000/nonexistent` should return `Content-Type: application/json` with body `{"status":404,"msg":"Not found"}`; `curl -i -X GET http://localhost:5000/register` should return 405 JSON.

## Closes #41