### PR TITLE
fix: resolve #31 - FEATURE: Refactor Save endpoint to use MongoDB $push instead

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -181,11 +181,7 @@ class Save(Resource):
         if not message:
             return {"status": 400, "msg": "message is required"}, 400
         username = request.username
-        messages = get_user_messages(username)
-        messages.append(message)
-
-        # save the new user message
-        users.update_one({"Username": username}, {"$set": {"Messages": messages}})
+        users.update_one({"Username": username}, {"$push": {"Messages": message}})
         return {"status": 200, "msg": "Message has been saved successfully"}, 200
 
 

--- a/web/tests/test_app.py
+++ b/web/tests/test_app.py
@@ -219,7 +219,6 @@ def test_save_expired_token_returns_401(mock_users, client):
 
 @patch("app.users")
 def test_save_valid_token_saves_and_returns_200(mock_users, client):
-    mock_users.find.return_value = make_user_cursor(username="alice", messages=[])
     token = make_valid_token(username="alice")
     rv = client.post(
         "/save",
@@ -257,7 +256,6 @@ def test_register_calls_insert_one(mock_users, client):
 @patch("app.users")
 def test_save_calls_update_one(mock_users, client):
     """Save must use update_one (not the deprecated update)."""
-    mock_users.find.return_value = make_user_cursor(username="alice", messages=[])
     token = make_valid_token(username="alice")
     client.post(
         "/save",
@@ -265,6 +263,11 @@ def test_save_calls_update_one(mock_users, client):
         headers={"Authorization": "Bearer " + token},
     )
     mock_users.update_one.assert_called_once()
+    # Verify the new $push operator is used, not $set.
+    call_args = mock_users.update_one.call_args
+    assert call_args[0][0] == {"Username": "alice"}
+    assert "$push" in call_args[0][1]
+    assert call_args[0][1]["$push"]["Messages"] == "hi"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Resolves #31 — FEATURE: Refactor Save endpoint to use MongoDB $push instead of fetch-all-then-$set
## Changes
- Lines 183-188 of `Save.post()` call `get_user_messages(username)` to fetch all existing messages into Python, append the new message to the in-memory list, then use `update_one` with `$set` to write the entire array back. This is a read-modify-write cycle that (a) makes an unnecessary database round
- The existing Save tests at lines 221-230 (`test_save_valid_token_saves_and_returns_200`) and lines 258-267 (`test_save_calls_update_one`) still set up a `find` mock return value because the old implementation calls `get_user_messages`, which internally calls `users.find`. After the refactor, `Save.p

**Tasks:**
- Replace lines 183-188 in `web/app.py` (`Save.post()`) with a single `users.update_one` call using `{"$push": {"Messages": message}}`, removing the `get_user_messages` call and the local `messages.append`.
- Keep the `get_user_messages` helper at lines 71-77 in `web/app.py` unchanged — it is still required by the `Retrieve` endpoint.
- Update `test_save_valid_token_saves_and_returns_200` in `web/tests/test_app.py` (line 221) to remove the `mock_users.find.return_value` setup, since the new `Save.post()` no longer calls `find`.
- Update `test_save_calls_update_one` in `web/tests/test_app.py` (line 258) to remove the `mock_users.find.return_value` setup for the same reason.
- Add a new test in `web/tests/test_app.py` that asserts `mock_users.update_one` is called with `{"$push": {"Messages": <message>}}` to verify the atomic push semantics and prevent regression to `$set`.
- All existing and new tests pass locally (`pytest -v` from project root).
- All existing and new lint checks pass locally (`./scripts/lint.sh` from project root).
## Testing
Run the full test suite — all tests must pass.
Closes #31