### PR TITLE
fix: resolve #33 - BUG: Add input length and type validation to prevent oversiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ production or multi-worker deployments, point it at a shared store such as
 Redis, e.g. `RATELIMIT_STORAGE_URL=redis://redis:6379`.
 
 
+## Input Validation
+
+To prevent oversized payloads from causing memory pressure or unnecessary
+bcrypt work, the API enforces the following per-field limits. Violations
+return HTTP 400 with a descriptive message.
+
+| Field      | Endpoint(s)        | Max length | Type   |
+|------------|--------------------|------------|--------|
+| username   | /register, /login  | 64 chars   | string |
+| password   | /register, /login  | 128 chars  | string |
+| message    | /save              | 1024 chars | string |
+
+Non-string values (e.g. a JSON number or array) for any of these fields also
+return HTTP 400.
+
+
 ## Using Postman
 
 Add `Content-Type: application/json` to your request headers.

--- a/web/app.py
+++ b/web/app.py
@@ -55,6 +55,15 @@ HELPER FUNCTIONS
 """
 
 
+def _require_string(value, max_len, field):
+    """Validate that *value* is a string and does not exceed *max_len*."""
+    if not isinstance(value, str):
+        return f"{field} must be a string"
+    if len(value) > max_len:
+        return f"{field} exceeds maximum length of {max_len}"
+    return None
+
+
 def user_exist(username):
     return users.find({"Username": username}).count() > 0
 
@@ -99,6 +108,11 @@ RESOURCES
 """
 
 
+MAX_USERNAME_LEN = 64
+MAX_PASSWORD_LEN = 128
+MAX_MESSAGE_LEN = 1024
+
+
 class Hello(Resource):
     """
     This is the Hello resource class
@@ -121,6 +135,12 @@ class Register(Resource):
             return {"status": 400, "msg": "Request body must be valid JSON"}, 400
         username = data.get("username")
         password = data.get("password")
+        err = _require_string(username, MAX_USERNAME_LEN, "username")
+        if err:
+            return {"status": 400, "msg": err}, 400
+        err = _require_string(password, MAX_PASSWORD_LEN, "password")
+        if err:
+            return {"status": 400, "msg": err}, 400
         if not username or not password:
             return {"status": 400, "msg": "username and password are required"}, 400
         if user_exist(username):
@@ -144,6 +164,12 @@ class Login(Resource):
             return {"status": 400, "msg": "Request body must be valid JSON"}, 400
         username = data.get("username")
         password = data.get("password")
+        err = _require_string(username, MAX_USERNAME_LEN, "username")
+        if err:
+            return {"status": 400, "msg": err}, 400
+        err = _require_string(password, MAX_PASSWORD_LEN, "password")
+        if err:
+            return {"status": 400, "msg": err}, 400
         if not username or not password:
             return {"status": 400, "msg": "username and password are required"}, 400
         if not verify_user(username, password):
@@ -178,6 +204,9 @@ class Save(Resource):
         if not data:
             return {"status": 400, "msg": "Request body must be valid JSON"}, 400
         message = data.get("message")
+        err = _require_string(message, MAX_MESSAGE_LEN, "message")
+        if err:
+            return {"status": 400, "msg": err}, 400
         if not message:
             return {"status": 400, "msg": "message is required"}, 400
         username = request.username

--- a/web/tests/test_app.py
+++ b/web/tests/test_app.py
@@ -128,6 +128,48 @@ def test_register_missing_body_returns_400(client):
     assert rv.status_code == 400
 
 
+@patch("app.users")
+def test_register_oversized_username_returns_400(mock_users, client):
+    mock_users.find.return_value = make_empty_cursor()
+    oversized = "a" * 65
+    rv = client.post("/register", json={"username": oversized, "password": "secret"})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "username" in data["msg"]
+    assert "64" in data["msg"]
+
+
+@patch("app.users")
+def test_register_oversized_password_returns_400(mock_users, client):
+    mock_users.find.return_value = make_empty_cursor()
+    oversized = "a" * 129
+    rv = client.post("/register", json={"username": "alice", "password": oversized})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "password" in data["msg"]
+    assert "128" in data["msg"]
+
+
+def test_register_non_string_username_returns_400(client):
+    rv = client.post("/register", json={"username": 123, "password": "secret"})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "username" in data["msg"]
+    assert "string" in data["msg"]
+
+
+def test_register_non_string_password_returns_400(client):
+    rv = client.post("/register", json={"username": "alice", "password": 456})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "password" in data["msg"]
+    assert "string" in data["msg"]
+
+
 # ---------------------------------------------------------------------------
 # Login
 # ---------------------------------------------------------------------------
@@ -161,6 +203,48 @@ def test_login_unknown_user_returns_401(mock_users, client):
 def test_login_missing_body_returns_400(client):
     rv = client.post("/login", json={})
     assert rv.status_code == 400
+
+
+@patch("app.users")
+def test_login_oversized_username_returns_400(mock_users, client):
+    mock_users.find.return_value = make_empty_cursor()
+    oversized = "a" * 65
+    rv = client.post("/login", json={"username": oversized, "password": "secret"})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "username" in data["msg"]
+    assert "64" in data["msg"]
+
+
+@patch("app.users")
+def test_login_oversized_password_returns_400(mock_users, client):
+    mock_users.find.return_value = make_empty_cursor()
+    oversized = "a" * 129
+    rv = client.post("/login", json={"username": "alice", "password": oversized})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "password" in data["msg"]
+    assert "128" in data["msg"]
+
+
+def test_login_non_string_username_returns_400(client):
+    rv = client.post("/login", json={"username": 123, "password": "secret"})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "username" in data["msg"]
+    assert "string" in data["msg"]
+
+
+def test_login_non_string_password_returns_400(client):
+    rv = client.post("/login", json={"username": "alice", "password": 456})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "password" in data["msg"]
+    assert "string" in data["msg"]
 
 
 # ---------------------------------------------------------------------------
@@ -238,6 +322,37 @@ def test_save_missing_message_returns_400(mock_users, client):
         headers={"Authorization": "Bearer " + token},
     )
     assert rv.status_code == 400
+
+
+@patch("app.users")
+def test_save_oversized_message_returns_400(mock_users, client):
+    token = make_valid_token(username="alice")
+    oversized = "a" * 1025
+    rv = client.post(
+        "/save",
+        json={"message": oversized},
+        headers={"Authorization": "Bearer " + token},
+    )
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "message" in data["msg"]
+    assert "1024" in data["msg"]
+
+
+@patch("app.users")
+def test_save_non_string_message_returns_400(mock_users, client):
+    token = make_valid_token(username="alice")
+    rv = client.post(
+        "/save",
+        json={"message": [1, 2, 3]},
+        headers={"Authorization": "Bearer " + token},
+    )
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "message" in data["msg"]
+    assert "string" in data["msg"]
 
 
 # ---------------------------------------------------------------------------

--- a/web/tests/test_app.py
+++ b/web/tests/test_app.py
@@ -152,8 +152,8 @@ def test_register_oversized_password_returns_400(mock_users, client):
     assert "128" in data["msg"]
 
 
-def test_register_non_string_username_returns_400(client):
-    rv = client.post("/register", json={"username": 123, "password": "secret"})
+def test_register_non_string_username_returns_400(rate_limited_client):
+    rv = rate_limited_client.post("/register", json={"username": 123, "password": "secret"})
     assert rv.status_code == 400
     data = rv.get_json()
     assert data["status"] == 400
@@ -161,8 +161,8 @@ def test_register_non_string_username_returns_400(client):
     assert "string" in data["msg"]
 
 
-def test_register_non_string_password_returns_400(client):
-    rv = client.post("/register", json={"username": "alice", "password": 456})
+def test_register_non_string_password_returns_400(rate_limited_client):
+    rv = rate_limited_client.post("/register", json={"username": "alice", "password": 456})
     assert rv.status_code == 400
     data = rv.get_json()
     assert data["status"] == 400


### PR DESCRIPTION
## Summary

Resolves #33 — Adds input length and type validation to all endpoints to prevent oversized payloads from causing memory pressure, MongoDB document bloat, or unnecessary bcrypt CPU work.

## Changes

- **web/app.py**: Added `_require_string` validation helper and constants `MAX_USERNAME_LEN` (64), `MAX_PASSWORD_LEN` (128), `MAX_MESSAGE_LEN` (1024). Called in `Register.post()`, `Login.post()`, and `Save.post()` to reject non-string values and over-length strings with HTTP 400.
- **README.md**: Added Input Validation section documenting the per-field limits and type requirements in a table.
- **web/tests/test_app.py**: Added unit tests covering oversized username, password, and message (returning 400), plus wrong-type inputs (JSON number, array) for each field.

## Testing

- Run `pytest -v web/tests/test_app.py` to execute the new validation tests.
- Manual verification: send a POST to `/register` or `/login` with a username over 64 chars, password over 128 chars, or message over 1024 chars — expect HTTP 400 with a descriptive error message. Similarly, send a JSON number or array for any field to confirm type validation.

## Closes #33