### PR TITLE
fix: resolve #48 - Add dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/web/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "dependencies"
+    groups:
+      all-dependencies:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary

Resolves #48 — Adds Dependabot configuration to automate dependency updates for the Python runtime and development dependencies pinned in `web/requirements.txt` and `web/requirements-dev.txt`, keeping the project's dependencies current with minimal manual effort.

## Changes

- **`.github/dependabot.yml`**: New file implementing Dependabot v2 configuration for the pip ecosystem. Sets `directory` to `/web/` (where `requirements.txt` and `requirements-dev.txt` reside), configures a monthly schedule with a limit of one open PR, and groups all dependencies under a single `all-dependencies` group with a `"*"` pattern. Uses `commit-message.prefix: "dependencies"` for conventional commit style.

## Testing

- Validate YAML syntax by parsing with a standard YAML loader (e.g. `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`).
- CI pipeline (`.github/workflows/ci.yml`) will automatically lint and test any Dependabot-generated PR — no additional manual testing required.
- After merging to `main`, Dependabot will begin scanning on its monthly schedule and surface available updates via PRs.

## Closes #48