### PR TITLE
fix: resolve #37 - BUG: Fix Dockerfile: remove --user flag from pip install (in

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 # copy requirements.txt into workdir created above
 COPY requirements.txt ./
 # Install all requirements
-RUN python3 -m pip install --user --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 # Copy entire project into workdir
 COPY . .
 # Run our app without output


### PR DESCRIPTION
## Summary

Resolves #37 — Remove the `--user` flag from the Dockerfile's pip install command to prevent potential `ModuleNotFoundError` at container startup, since packages installed to `/root/.local` may not be on `sys.path` when Python is invoked as `python app.py`.

## Changes

- **web/Dockerfile**: Removed `--user` flag from the pip install command, changing `RUN python3 -m pip install --user --no-cache-dir -r requirements.txt` to `RUN pip install --no-cache-dir -r requirements.txt` so packages install to system site-packages where they are reliably discoverable at runtime.

## Testing

- Build and start the containers: `docker-compose build && docker-compose up`
- Verify the API responds: `curl http://localhost:5000/hello` returns `Hello World!`

## Closes #37