### PR TITLE
fix: resolve #39 - FEATURE: Add pagination support to /retrieve endpoint for la

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,12 @@ On invalid credentials the endpoint returns 401.
 Pass the token in the `Authorization` header on every call to `/retrieve` and `/save`:
 
 ```shell
-# Retrieve messages
+# Retrieve messages (default: first 20, total count included)
 curl -X POST http://localhost:5000/retrieve \
+  -H "Authorization: Bearer ***"
+
+# Retrieve messages with pagination — offset and limit are optional
+curl -X POST "http://localhost:5000/retrieve?offset=20&limit=10" \
   -H "Authorization: Bearer ***"
 
 # Save a message
@@ -117,6 +121,19 @@ curl -X POST http://localhost:5000/save \
   -H "Authorization: Bearer ***" \
   -H "Content-Type: application/json" \
   -d '{"message": "Hello!"}'
+```
+
+The `/retrieve` endpoint supports two optional query parameters:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `offset`  | `0`     | Zero-based index of the first message to return. |
+| `limit`   | `20`    | Maximum number of messages to return. Capped at **100** server-side. |
+
+The response includes a `total` field with the full message count for the authenticated user, allowing clients to paginate through the entire collection:
+
+```json
+{"status": 200, "obj": ["msg-0", "msg-1"], "total": 50}
 ```
 
 Missing, expired, or tampered tokens return 401 Unauthorized.

--- a/web/app.py
+++ b/web/app.py
@@ -189,8 +189,12 @@ class Retrieve(Resource):
 
     @requires_auth
     def post(self):
-        messages = get_user_messages(request.username)
-        return {"status": 200, "obj": messages}, 200
+        offset = request.args.get("offset", 0, type=int)
+        limit = request.args.get("limit", 20, type=int)
+        limit = min(limit, 100)
+        all_messages = get_user_messages(request.username)
+        page = all_messages[offset : offset + limit]
+        return {"status": 200, "obj": page, "total": len(all_messages)}, 200
 
 
 class Save(Resource):

--- a/web/tests/test_app.py
+++ b/web/tests/test_app.py
@@ -284,6 +284,98 @@ def test_retrieve_valid_token_returns_messages(mock_users, client):
     assert "hello" in data["obj"]
 
 
+@patch("app.users")
+def test_retrieve_default_pagination_returns_first_20_with_total(mock_users, client):
+    messages = [f"msg-{i}" for i in range(50)]
+    mock_users.count_documents.return_value = 1
+    mock_users.find.return_value = make_user_cursor(username="alice", messages=messages)
+    token = make_valid_token(username="alice")
+    rv = client.post(
+        "/retrieve", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["status"] == 200
+    assert data["total"] == 50
+    assert len(data["obj"]) == 20
+    assert data["obj"] == messages[:20]
+
+
+@patch("app.users")
+def test_retrieve_custom_limit_returns_requested_number(mock_users, client):
+    messages = [f"msg-{i}" for i in range(20)]
+    mock_users.count_documents.return_value = 1
+    mock_users.find.return_value = make_user_cursor(username="alice", messages=messages)
+    token = make_valid_token(username="alice")
+    rv = client.post(
+        "/retrieve",
+        headers={"Authorization": f"Bearer {token}"},
+        query_string="limit=5",
+    )
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["status"] == 200
+    assert data["total"] == 20
+    assert len(data["obj"]) == 5
+    assert data["obj"] == messages[:5]
+
+
+@patch("app.users")
+def test_retrieve_custom_offset_skips_correct_messages(mock_users, client):
+    messages = [f"msg-{i}" for i in range(20)]
+    mock_users.count_documents.return_value = 1
+    mock_users.find.return_value = make_user_cursor(username="alice", messages=messages)
+    token = make_valid_token(username="alice")
+    rv = client.post(
+        "/retrieve",
+        headers={"Authorization": f"Bearer {token}"},
+        query_string="offset=5&limit=5",
+    )
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["status"] == 200
+    assert data["total"] == 20
+    assert len(data["obj"]) == 5
+    assert data["obj"] == messages[5:10]
+
+
+@patch("app.users")
+def test_retrieve_offset_beyond_collection_returns_empty_page(mock_users, client):
+    messages = [f"msg-{i}" for i in range(10)]
+    mock_users.count_documents.return_value = 1
+    mock_users.find.return_value = make_user_cursor(username="alice", messages=messages)
+    token = make_valid_token(username="alice")
+    rv = client.post(
+        "/retrieve",
+        headers={"Authorization": f"Bearer {token}"},
+        query_string="offset=20&limit=5",
+    )
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["status"] == 200
+    assert data["total"] == 10
+    assert data["obj"] == []
+
+
+@patch("app.users")
+def test_retrieve_limit_capped_at_100(mock_users, client):
+    messages = [f"msg-{i}" for i in range(150)]
+    mock_users.count_documents.return_value = 1
+    mock_users.find.return_value = make_user_cursor(username="alice", messages=messages)
+    token = make_valid_token(username="alice")
+    rv = client.post(
+        "/retrieve",
+        headers={"Authorization": f"Bearer {token}"},
+        query_string="limit=200",
+    )
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["status"] == 200
+    assert data["total"] == 150
+    assert len(data["obj"]) == 100
+    assert data["obj"] == messages[:100]
+
+
 # ---------------------------------------------------------------------------
 # Save
 # ---------------------------------------------------------------------------

--- a/web/tests/test_app.py
+++ b/web/tests/test_app.py
@@ -290,9 +290,7 @@ def test_retrieve_default_pagination_returns_first_20_with_total(mock_users, cli
     mock_users.count_documents.return_value = 1
     mock_users.find.return_value = make_user_cursor(username="alice", messages=messages)
     token = make_valid_token(username="alice")
-    rv = client.post(
-        "/retrieve", headers={"Authorization": f"Bearer {token}"}
-    )
+    rv = client.post("/retrieve", headers={"Authorization": f"Bearer {token}"})
     assert rv.status_code == 200
     data = rv.get_json()
     assert data["status"] == 200


### PR DESCRIPTION
## Summary

Resolves #39 — Adds pagination support to the `/retrieve` endpoint so users with large message collections can fetch messages in bounded chunks instead of receiving the entire array in one response.

## Changes

- **web/app.py**: Modified `Retrieve.post()` to accept optional `offset` and `limit` query parameters (defaults: 0 and 20), cap `limit` at 100 server-side, and return a `total` field alongside the paginated slice so clients can page through the full collection.
- **web/tests/test_app.py**: Added three new test cases — `test_retrieve_default_pagination_returns_first_20_with_total`, `test_retrieve_custom_limit_returns_requested_number`, and `test_retrieve_custom_offset_skips_correct_messages` — covering default pagination, custom limit, and custom offset scenarios.
- **README.md**: Documented the new `offset` and `limit` query parameters in a parameter table and added an example curl command showing pagination usage.

## Testing

Run the new pagination tests with `pytest web/tests/test_app.py::test_retrieve_default_pagination_returns_first_20_with_total web/tests/test_app.py::test_retrieve_custom_limit_returns_requested_number web/tests/test_app.py::test_retrieve_custom_offset_skips_correct_messages -v`. All tests mock the MongoDB layer via `@patch("app.users")` and verify status code, total count, slice length, and slice contents.

## Closes #39