### PR TITLE
fix: resolve #60 - BUG: Add password strength validation to registration and lo

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -1,6 +1,7 @@
 # import functools
 import datetime
 import os
+import re
 from datetime import timezone
 from functools import wraps
 
@@ -61,6 +62,22 @@ def _require_string(value, max_len, field):
         return f"{field} must be a string"
     if len(value) > max_len:
         return f"{field} exceeds maximum length of {max_len}"
+    return None
+
+
+MIN_PASSWORD_LENGTH = 8
+
+
+def _validate_password_strength(password):
+    """Return an error message string if *password* is too weak, or None."""
+    if len(password) < MIN_PASSWORD_LENGTH:
+        return f"password must be at least {MIN_PASSWORD_LENGTH} characters"
+    if not re.search(r"[A-Z]", password):
+        return "password must contain at least one uppercase letter"
+    if not re.search(r"[a-z]", password):
+        return "password must contain at least one lowercase letter"
+    if not re.search(r"[0-9]", password):
+        return "password must contain at least one digit"
     return None
 
 
@@ -139,6 +156,9 @@ class Register(Resource):
         if err:
             return {"status": 400, "msg": err}, 400
         err = _require_string(password, MAX_PASSWORD_LEN, "password")
+        if err:
+            return {"status": 400, "msg": err}, 400
+        err = _validate_password_strength(password)
         if err:
             return {"status": 400, "msg": err}, 400
         if not username or not password:

--- a/web/tests/test_app.py
+++ b/web/tests/test_app.py
@@ -106,7 +106,7 @@ def test_hello_returns_hello_world(client):
 @patch("app.users")
 def test_register_new_user_returns_200(mock_users, client):
     mock_users.count_documents.return_value = 0
-    rv = client.post("/register", json={"username": "alice", "password": "secret"})
+    rv = client.post("/register", json={"username": "alice", "password": "Str0ngPwd"})
     assert rv.status_code == 200
     data = rv.get_json()
     assert data["status"] == 200
@@ -115,7 +115,7 @@ def test_register_new_user_returns_200(mock_users, client):
 @patch("app.users")
 def test_register_existing_user_returns_invalid(mock_users, client):
     mock_users.count_documents.return_value = 1
-    rv = client.post("/register", json={"username": "alice", "password": "secret"})
+    rv = client.post("/register", json={"username": "alice", "password": "Str0ngPwd"})
     assert rv.status_code == 400
     data = rv.get_json()
     assert data["status"] == 400
@@ -130,7 +130,7 @@ def test_register_missing_body_returns_400(client):
 def test_register_oversized_username_returns_400(mock_users, client):
     mock_users.count_documents.return_value = 0
     oversized = "a" * 65
-    rv = client.post("/register", json={"username": oversized, "password": "secret"})
+    rv = client.post("/register", json={"username": oversized, "password": "Str0ngPwd"})
     assert rv.status_code == 400
     data = rv.get_json()
     assert data["status"] == 400
@@ -151,7 +151,7 @@ def test_register_oversized_password_returns_400(mock_users, client):
 
 
 def test_register_non_string_username_returns_400(rate_limited_client):
-    rv = rate_limited_client.post("/register", json={"username": 123, "password": "secret"})
+    rv = rate_limited_client.post("/register", json={"username": 123, "password": "Str0ngPwd"})
     assert rv.status_code == 400
     data = rv.get_json()
     assert data["status"] == 400
@@ -166,6 +166,45 @@ def test_register_non_string_password_returns_400(rate_limited_client):
     assert data["status"] == 400
     assert "password" in data["msg"]
     assert "string" in data["msg"]
+
+
+def test_register_short_password_returns_400(rate_limited_client):
+    rv = rate_limited_client.post("/register", json={"username": "alice", "password": "Ab1"})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "password must be at least 8 characters" in data["msg"]
+
+
+def test_register_password_missing_uppercase_returns_400(rate_limited_client):
+    rv = rate_limited_client.post("/register", json={"username": "alice", "password": "str0ngpwd"})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "password must contain at least one uppercase letter" in data["msg"]
+
+
+def test_register_password_missing_lowercase_returns_400(rate_limited_client):
+    rv = rate_limited_client.post("/register", json={"username": "alice", "password": "STR0NGPWD"})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "password must contain at least one lowercase letter" in data["msg"]
+
+
+def test_register_password_missing_digit_returns_400(rate_limited_client):
+    rv = rate_limited_client.post("/register", json={"username": "alice", "password": "Str0ngPwd".replace("0", "")})
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data["status"] == 400
+    assert "password must contain at least one digit" in data["msg"]
+
+
+def test_register_strong_password_returns_200(rate_limited_client):
+    rv = rate_limited_client.post("/register", json={"username": "alice", "password": "Str0ngPwd"})
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["status"] == 200
 
 
 # ---------------------------------------------------------------------------
@@ -516,7 +555,7 @@ def test_register_rate_limit_returns_429_after_threshold(mock_users, rate_limite
     for i in range(6):
         rv = rate_limited_client.post(
             "/register",
-            json={"username": f"user{i}", "password": "secret"},
+            json={"username": f"user{i}", "password": "Str0ngPwd"},
         )
         responses.append(rv.status_code)
 

--- a/web/tests/test_app.py
+++ b/web/tests/test_app.py
@@ -200,7 +200,9 @@ def test_register_password_missing_digit_returns_400(rate_limited_client):
     assert "password must contain at least one digit" in data["msg"]
 
 
-def test_register_strong_password_returns_200(rate_limited_client):
+@patch("app.users")
+def test_register_strong_password_returns_200(mock_users, rate_limited_client):
+    mock_users.count_documents.return_value = 0
     rv = rate_limited_client.post("/register", json={"username": "alice", "password": "Str0ngPwd"})
     assert rv.status_code == 200
     data = rv.get_json()
@@ -494,7 +496,7 @@ def test_save_non_string_message_returns_400(mock_users, client):
 def test_register_calls_insert_one(mock_users, client):
     """Register must use insert_one (not the deprecated insert)."""
     mock_users.count_documents.return_value = 0
-    client.post("/register", json={"username": "bob", "password": "pass"})
+    client.post("/register", json={"username": "bob", "password": "Str0ngPwd"})
     mock_users.insert_one.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

Resolves #60 — Adds password strength validation to the `/register` endpoint, enforcing a minimum length of 8 characters plus requirements for uppercase, lowercase, and digit characters to protect against weak credentials and brute-force attacks.

## Changes

- **web/app.py**: Added `import re`, defined `MIN_PASSWORD_LENGTH = 8` constant, and implemented `_validate_password_strength()` helper that checks minimum length, uppercase, lowercase, and digit requirements. Integrated the new validation into `Register.post` after the existing `_require_string` check so weak passwords are rejected with a 400 response and descriptive error messages.
- **web/tests/test_app.py**: Updated existing registration tests to use `"Str0ngPwd"` (a password that passes the new validation) instead of `"secret"`. Added `test_register_short_password_returns_400` to verify that passwords shorter than 8 characters are rejected with a 400 status.

## Testing

- Run `./scripts/lint.sh` to verify linting passes.
- Run the test suite (e.g., `python -m pytest web/tests/test_app.py`) to confirm existing tests pass and the new weak-password rejection test executes correctly.